### PR TITLE
Fix console_util import

### DIFF
--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -13,10 +13,10 @@ import os
 import argparse
 import ruamel.yaml
 import re
-import mitmproxy2swagger.console_util
-from mitmproxy2swagger.har_capture_reader import HarCaptureReader, har_archive_heuristic
-from mitmproxy2swagger.mitmproxy_capture_reader import MitmproxyCaptureReader, mitmproxy_dump_file_huristic
-import mitmproxy2swagger.console_util
+from . import swagger_util
+from .har_capture_reader import HarCaptureReader, har_archive_heuristic
+from .mitmproxy_capture_reader import MitmproxyCaptureReader, mitmproxy_dump_file_huristic
+from . import console_util
 
 def path_to_regex(path):
     # replace the path template with a regex


### PR DESCRIPTION
I get this error with 0.5.1:

```
% mitmproxy2swagger -i flows -o foo -p https://api.example.com/v1
Traceback (most recent call last):
  File "/usr/bin/mitmproxy2swagger", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3.10/site-packages/mitmproxy2swagger/mitmproxy2swagger.py", line 107, in main
    for f in caputre_reader.captured_requests():
  File "/usr/lib/python3.10/site-packages/mitmproxy2swagger/mitmproxy_capture_reader.py", line 77, in captured_requests
    self.progress_callback(logfile.tell() / logfile_size)
  File "/usr/lib/python3.10/site-packages/mitmproxy2swagger/mitmproxy2swagger.py", line 39, in progress_callback
    console_util.print_progress_bar(progress)
NameError: name 'console_util' is not defined
```

It's imported as `mitmproxy2swagger.console_util`, I've changed this to a relative imports and I think swagger_util is also still needed and instead console_util was mistakenly imported twice. :)

Related to #4