### PR TITLE
Update har_capture_reader.py

### DIFF
--- a/mitmproxy2swagger/har_capture_reader.py
+++ b/mitmproxy2swagger/har_capture_reader.py
@@ -71,9 +71,9 @@ class HarCaptureReader:
         self.progress_callback = progress_callback
     def captured_requests(self) -> Iterator[HarFlowWrapper]:
         har_file_size = os.path.getsize(self.file_path)
-        with open(self.file_path, 'r') as f:
+        with open(self.file_path, 'r', encoding='utf-8') as f:
             data = json_stream.load(f)
-            for entry in data['log']['entries'].persistent():       
+            for entry in data['log']['entries'].persistent():
                 if self.progress_callback:
                     self.progress_callback(f.tell() / har_file_size)
                 yield HarFlowWrapper(entry)


### PR DESCRIPTION
Added UTF-8 encoding to HAR capture reader.

I was testing out the new HAR reader functionality and one of my captures contained unicode characters. This caused a parsing error when attempting to load as input for mitmproxy2swagger:
`UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 7711: character maps to <undefined>`

Adding UTF-8 encoding resolved this.