### PR TITLE
fix two encoding issues

### DIFF
--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -149,6 +149,8 @@ def main():
                     # try to parse the body as json
                     try:
                         body_val = json.loads(f.get_request_body())
+                    except UnicodeDecodeError:
+                        pass
                     except json.decoder.JSONDecodeError:
                         pass
                     if body_val is not None:
@@ -170,6 +172,8 @@ def main():
             if response_body is not None:
                 try:
                     response_json = json.loads(response_body)
+                except UnicodeDecodeError:
+                    response_json = None
                 except json.decoder.JSONDecodeError:
                     response_json = None
                 if response_json is not None:


### PR DESCRIPTION
File ".local/lib/python3.10/site-packages/mitmproxy2swagger/mitmproxy2swagger.py", line 172, in main
    response_json = json.loads(response_body)
  File "/usr/lib/python3.10/json/__init__.py", line 341, in loads
    s = s.decode(detect_encoding(s), 'surrogatepass')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte

File "mitmproxy2swagger/mitmproxy2swagger.py", line 151, in main
    body_val = json.loads(f.get_request_body())
  File "/usr/lib/python3.10/json/__init__.py", line 341, in loads
    s = s.decode(detect_encoding(s), 'surrogatepass')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 144: invalid start byte