### PR TITLE
fix: detect base64-encoded responses

### DIFF
--- a/mitmproxy2swagger/har_capture_reader.py
+++ b/mitmproxy2swagger/har_capture_reader.py
@@ -1,5 +1,6 @@
 import os
 import json_stream
+from base64 import b64decode
 from typing import Iterator
 
 
@@ -72,6 +73,8 @@ class HarFlowWrapper:
 
     def get_response_body(self):
         if 'response' in self.flow and 'content' in self.flow['response'] and 'text' in self.flow['response']['content']:
+            if 'encoding' in self.flow['response']['content'] and self.flow['response']['content']['encoding'] == 'base64':
+                return b64decode(self.flow['response']['content']['text']).decode()
             return self.flow['response']['content']['text']
         return None
 


### PR DESCRIPTION
[Charles Proxy](https://www.charlesproxy.com/) exports HAR files with base64-encoded responses, which mitmproxy2swagger doesn't recognize, thus skipping all responses and producing invalid YAML files.