### PR TITLE
Fix type hinting for Python3.9

### DIFF
--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -8,7 +8,7 @@ import re
 import sys
 import traceback
 import urllib
-from typing import Any, Sequence
+from typing import Any, Optional, Sequence, Union
 
 import ruamel.yaml
 from mitmproxy.exceptions import FlowReadException
@@ -63,7 +63,7 @@ def detect_input_format(file_path):
     return MitmproxyCaptureReader(file_path, progress_callback)
 
 
-def main(override_args: Sequence[str] | None = None):
+def main(override_args: Optional[Sequence[str]] = None):
     parser = argparse.ArgumentParser(
         description="Converts a mitmproxy dump file or HAR to a swagger schema."
     )
@@ -102,7 +102,7 @@ def main(override_args: Sequence[str] | None = None):
 
     yaml = ruamel.yaml.YAML()
 
-    capture_reader: MitmproxyCaptureReader | HarCaptureReader
+    capture_reader: Union[MitmproxyCaptureReader, HarCaptureReader]
     if args.format == "flow" or args.format == "mitmproxy":
         capture_reader = MitmproxyCaptureReader(args.input, progress_callback)
     elif args.format == "har":

--- a/mitmproxy2swagger/testing_util.py
+++ b/mitmproxy2swagger/testing_util.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import tempfile
-from typing import Any, List
+from typing import Any, List, Optional
 
 import ruamel.yaml as ruamel
 
@@ -21,7 +21,7 @@ def get_nested_key(obj: Any, path: str) -> Any:
 
 
 def mitmproxy2swagger_e2e_test(
-    input_file: str, url_prefix: str, extra_args: List[str] | None = None
+    input_file: str, url_prefix: str, extra_args: Optional[List[str]] = None
 ) -> Any:
     """Runs mitmproxy2swagger on the given input file twice, and returns the
     detected endpoints."""


### PR DESCRIPTION
Support for unions written as `X | Y` is only available in Python3.10 and up!
See: https://docs.python.org/3/library/typing.html#typing.Union