### PR TITLE
feat: add customizable param regex and suppression

### DIFF
--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -115,7 +115,9 @@ def main(override_args: Optional[Sequence[str]] = None):
     try:
         args.param_regex = re.compile("^" + args.param_regex + "$")
     except re.error as e:
-        print(f"{console_util.ANSI_RED}Invalid path parameter regex: {e}{console_util.ANSI_RESET}")
+        print(
+            f"{console_util.ANSI_RED}Invalid path parameter regex: {e}{console_util.ANSI_RESET}"
+        )
         sys.exit(1)
 
     yaml = ruamel.yaml.YAML()


### PR DESCRIPTION
This adds 2 new command line flags:
- `-r`, `--param-regex`: Allows the user to customize what path segment value will be considered as a parameter.
- `s`, `--suppress-params`: Only outputs the "templated" path with the parameter variables, but not the originals with the actual parameters.