### PR TITLE
Fix number/boolean and nullable object generation

### DIFF
--- a/mitmproxy2swagger/swagger_util.py
+++ b/mitmproxy2swagger/swagger_util.py
@@ -112,7 +112,7 @@ def response_to_headers(headers):
 
 def value_to_schema(value):
     # check if value is a number
-    if isinstance(value, (int, float)):
+    if type(value) is int or type(value) is float:
         return {"type": "number"}
     # check if value is a boolean
     elif isinstance(value, bool):
@@ -143,7 +143,11 @@ def value_to_schema(value):
         }
     # if it is none, return null
     elif value is None:
-        return {"type": "object"}
+        return {
+            "type": "object",
+            "nullable": True
+        }
+
 
 
 def is_uuid(key):

--- a/mitmproxy2swagger/swagger_util.py
+++ b/mitmproxy2swagger/swagger_util.py
@@ -143,11 +143,7 @@ def value_to_schema(value):
         }
     # if it is none, return null
     elif value is None:
-        return {
-            "type": "object",
-            "nullable": True
-        }
-
+        return {"type": "object", "nullable": True}
 
 
 def is_uuid(key):


### PR DESCRIPTION
Boolean is a type of int:
```
isinstance(True, (int, float))
True
```

Therefore, deciding if a value is a number or a boolean doesn't work.

The fix is either check for bool first then for number but then the correctness depends on the order of the operations.
Using the exact type match makes it a bit clearer IMHO.