### PR TITLE
Avoid AttributeError when key or value are already decoded

### DIFF
--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -262,7 +262,11 @@ def main(override_args: Optional[Sequence[str]] = None):
                             did_find_anything = False
                             for key, value in body_val_bytes.items():
                                 did_find_anything = True
-                                body_val[key.decode("utf-8")] = value.decode("utf-8")
+                                if type(key) != str:
+                                    key = key.decode("utf-8")
+                                if type(value) != str:
+                                    value = value.decode("utf-8")
+                                body_val[key] = value
                             if did_find_anything:
                                 content_type = "application/x-www-form-urlencoded"
                             else:


### PR DESCRIPTION
I got the error:
```
File "/usr/bin/mitmproxy2swagger", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.12/site-packages/mitmproxy2swagger/mitmproxy2swagger.py", line 265, in main
    body_val[key.decode("utf-8")] = value.decode("utf-8")
                                    ^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```
and fixed it by the current change.