### PR TITLE
fix: remove deprecated poetry config command from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /app
 RUN uv pip install --system poetry poetry-plugin-export
 COPY pyproject.toml poetry.lock ./
 RUN uv venv /venv && \
-    poetry config warnings.export false && \
     poetry export -f requirements.txt -o requirements.txt && \
     VIRTUAL_ENV=/venv uv pip install -r requirements.txt
 COPY . .
@@ -22,3 +21,4 @@ COPY --from=builder /venv /venv
 ENV PATH="/venv/bin:${PATH}"
 
 ENTRYPOINT [ "mitmproxy2swagger" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,3 @@ COPY --from=builder /venv /venv
 ENV PATH="/venv/bin:${PATH}"
 
 ENTRYPOINT [ "mitmproxy2swagger" ]
-


### PR DESCRIPTION
The error occurs because the Poetry command to set `warnings.export` is no longer valid in newer versions of Poetry. This PR removes the deprecated configuration line:

`poetry config warnings.export false`


This configuration is no longer needed in recent versions of Poetry, and the export command works fine without it.