### PR TITLE
Fix Dockerfile by removing invalid Poetry Config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /app
 RUN uv pip install --system poetry poetry-plugin-export
 COPY pyproject.toml poetry.lock ./
 RUN uv venv /venv && \
-    poetry config warnings.export false && \
     poetry export -f requirements.txt -o requirements.txt && \
     VIRTUAL_ENV=/venv uv pip install -r requirements.txt
 COPY . .


### PR DESCRIPTION
`poetry config warnings.export false` was causing an error when building Docker images.
I checked the config list for poetry and couldn't find the `warnings.export` config.