### PR TITLE
Use utf-8 while saving the swagger file

### DIFF
--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -430,7 +430,7 @@ def main(override_args: Optional[Sequence[str]] = None):
         "Remove the ignore: prefix to generate an endpoint with its URL\nLines that are closer to the top take precedence, the matching is greedy"
     )
     # save the swagger file
-    with open(args.output, "w") as f:
+    with open(args.output, "w", encoding="utf-8") as f:
         yaml.dump(swagger, f)
     print("Done!")
 


### PR DESCRIPTION
Use utf-8 while saving the swagger file to fix "UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-1: character maps to <undefined>". Probably happens on windows without force utf-8 mode