### PR TITLE
Fix missing path parameters when also adding headers

### DIFF
--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -221,7 +221,7 @@ def main(override_args: Optional[Sequence[str]] = None):
                     set_key_if_not_exists(
                         swagger["paths"][path_template_to_set][method],
                         "parameters",
-                        headers_request,
+                        headers_request + (params or []),
                     )
             if params is not None and len(params) > 0:
                 set_key_if_not_exists(


### PR DESCRIPTION
mitmproxy2swagger adds path parameters like `/{id}` correctly as
```
      parameters:
      - name: id
        in: path
        required: true
        schema:
          type: string
```

When using `mitmproxy2swagger --headers` the headers are added, but the parameters will be missing:

```
      parameters:
      - name: content-type
        in: header
        required: false
        schema:
          type: string
```

The correct result should be

```
      parameters:
      - name: content-type
        in: header
        required: false
        schema:
          type: string
      - name: id
        in: path
        required: true
        schema:
          type: string
```

The reason for this bug is that if `args.headers` is used, the key `parameters` in `swagger` is already set and the later `set_key_if_not_exists` for `params` does not extend the key `parameters`.
One (least invasive) fix is to merge both arrays.
