### PR TITLE
Fix: Remove invalid poetry config command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /app
 RUN uv pip install --system poetry poetry-plugin-export
 COPY pyproject.toml poetry.lock ./
 RUN uv venv /venv && \
-    poetry config warnings.export false && \
     poetry export -f requirements.txt -o requirements.txt && \
     VIRTUAL_ENV=/venv uv pip install -r requirements.txt
 COPY . .


### PR DESCRIPTION
This pull request fixes a build error that occurs when building the Docker image on a fresh Kali Linux installation. The poetry config warnings.export false command is no longer valid in recent versions of Poetry and causes the build to fail. This change removes the invalid command, allowing the Docker image to be built successfully.