### PR TITLE
Fix: Merge headers and query parameters when using -hd flag

### DIFF
--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -226,7 +226,9 @@ def main(override_args: Optional[Sequence[str]] = None):
 
             if len(all_params) > 0:
                 set_key_if_not_exists(
-                    swagger["paths"][path_template_to_set][method], "parameters", all_params
+                    swagger["paths"][path_template_to_set][method],
+                    "parameters",
+                    all_params,
                 )
 
             if method not in ["get", "head"]:

--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -213,19 +213,20 @@ def main(override_args: Optional[Sequence[str]] = None):
             )
 
             params = swagger_util.url_to_params(url, path_template_to_set)
+            all_params = []
             if args.headers:
                 headers_request = swagger_util.request_to_headers(
                     req.get_request_headers()
                 )
                 if headers_request is not None and len(headers_request) > 0:
-                    set_key_if_not_exists(
-                        swagger["paths"][path_template_to_set][method],
-                        "parameters",
-                        headers_request,
-                    )
+                    all_params.extend(headers_request)
+
             if params is not None and len(params) > 0:
+                all_params.extend(params)
+
+            if len(all_params) > 0:
                 set_key_if_not_exists(
-                    swagger["paths"][path_template_to_set][method], "parameters", params
+                    swagger["paths"][path_template_to_set][method], "parameters", all_params
                 )
 
             if method not in ["get", "head"]:


### PR DESCRIPTION
When using the -hd flag, headers were included in the OpenAPI spec but query parameters were excluded. Without -hd, query parameters were included but headers were not. I modified the parameter handling logic to merge headers and query parameters into a single list before setting the parameters key, so both headers and parameters are included